### PR TITLE
fix: add `remark-github` plugin to bundle

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -91,6 +91,11 @@ export default defineNuxtModule<ModuleOptions>({
         context.markdown.remarkPlugins = context.markdown.remarkPlugins || {}
         context.markdown.remarkPlugins['remark-github'] = { repository: `${options.owner}/${options.repo}` }
       })
+      // Add `remark-github` plugin to bundle
+      nuxt.hook('nitro:config', (nitroConfig) => {
+        nitroConfig.externals.traceInclude = nitroConfig.externals.traceInclude || []
+        nitroConfig.externals.traceInclude.push('node_modules/remark-github/index.js')
+      })
     }
 
     const nitroConfig = nuxt.options.nitro


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
resolves #33
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
/cc @pi0 @danielroe It is strange that when I add the package name to the `traceInclude`, rollup raise an exception

<img width="509" alt="Screenshot 2022-08-19 at 11 53 29" src="https://user-images.githubusercontent.com/2047945/185593860-7bf48c36-3506-4a54-afe3-1c92a4ce8f65.png">

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
