### PR TITLE
fix: remove explicit `traceInclude`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -91,11 +91,6 @@ export default defineNuxtModule<ModuleOptions>({
         context.markdown.remarkPlugins = context.markdown.remarkPlugins || {}
         context.markdown.remarkPlugins['remark-github'] = { repository: `${options.owner}/${options.repo}` }
       })
-      // Add `remark-github` plugin to bundle
-      nuxt.hook('nitro:config', (nitroConfig) => {
-        nitroConfig.externals.traceInclude = nitroConfig.externals.traceInclude || []
-        nitroConfig.externals.traceInclude.push('node_modules/remark-github/index.js')
-      })
     }
 
     const nitroConfig = nuxt.options.nitro


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently this causes an error:

<img width="1084" alt="CleanShot_2022-11-15_at_13 51 202x" src="https://user-images.githubusercontent.com/28706372/201936658-561d907c-cdb4-4f99-aa58-5ba3bfef33f6.png">

I suspect this was originally to work around a problem with the nitro trace implementation but in my testing `remark-github/index.js` does get successfully traced and added to `node_modules` in server directory - so hopefully the original issue was resolved upstream in nitro.


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
