### PR TITLE
refactor: replace deprecated `addAutoImport` with `addImports`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1,13 +1,8 @@
 import { defu } from 'defu'
-import { addAutoImport, addComponent, createResolver, defineNuxtModule, resolveModule } from '@nuxt/kit'
+import { addImports, addComponent, createResolver, defineNuxtModule, resolveModule } from '@nuxt/kit'
 import type { GithubRepositoryOptions } from './runtime/types'
 
 export interface ModuleOptions extends GithubRepositoryOptions {
-  owner?: string
-  branch?: string
-  repo?: string
-  api?: string
-  token?: string
   disableCache?: boolean
   remarkPlugin?: boolean
   releases?: boolean
@@ -202,7 +197,7 @@ export default defineNuxtModule<ModuleOptions>({
       })
     }
 
-    addAutoImport({
+    addImports({
       name: 'useGithub',
       from: resolveModule('./composables/useGithub', { paths: runtimeDir })
     })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

- replace deprecated `addAutoImport` with `addImports` 
- remove duplicated declarations for `GithubRepositoryOptions` props in `ModuleOptions`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
